### PR TITLE
workaround lack of homebrew bottle for ada-url on Linux

### DIFF
--- a/scripts/homebrew-install-and-cache.sh
+++ b/scripts/homebrew-install-and-cache.sh
@@ -20,11 +20,22 @@ if [ "$(uname)" == Darwin ] ; then
 fi
 
 # Install packages via Homebrew, quieting reinstall warnings if necessary
-brew install --quiet "$CC_PKG" cmake ada-url curl duktape jansson pcre2 protobuf-c
+brew install --quiet "$CC_PKG" cmake curl duktape jansson pcre2 protobuf-c
 
-# Apply Ubuntu-specific tweaks
-if [ "$(uname)" == Linux ] ; then
+if [ "$(uname)" == Darwin ] ; then
+	brew install --quiet ada-url
+elif [ "$(uname)" == Linux ] ; then
+	# Workaround lack of ada-url bottle (Homebrew binary package) on Linux
+	# https://github.com/Homebrew/homebrew-core/pull/233020
+	curl -Lo ada.tgz https://github.com/ada-url/ada/archive/refs/tags/v3.2.7.tar.gz
+	tar zxf ada.tgz
+	cmake -S ada-3.2.7 -B ada-build -DBUILD_SHARED_LIBS=ON
+	cmake --build ada-build
+	sudo cmake --install ada-build
+	rm -rf ada.tgz ada-3.2.7 ada-build
+	# Install Linux-specific packages
 	brew install --quiet libseccomp
+	# Ubuntu: change default shell from dash to bash
 	sudo mv /bin/sh{,bak}
 	sudo ln -s /bin/{bash,sh}
 fi


### PR DESCRIPTION
Workaround recent change to ada-url package on Homebrew: https://github.com/Homebrew/homebrew-core/pull/233020