### PR TITLE
workaround lack of homebrew bottle for ada-url on Linux (take 2)

### DIFF
--- a/scripts/homebrew-install-and-cache.sh
+++ b/scripts/homebrew-install-and-cache.sh
@@ -29,9 +29,9 @@ elif [ "$(uname)" == Linux ] ; then
 	# https://github.com/Homebrew/homebrew-core/pull/233020
 	curl -Lo ada.tgz https://github.com/ada-url/ada/archive/refs/tags/v3.2.7.tar.gz
 	tar zxf ada.tgz
-	cmake -S ada-3.2.7 -B ada-build -DBUILD_SHARED_LIBS=ON
+	cmake -S ada-3.2.7 -B ada-build --install-prefix "$(brew --prefix)" -DBUILD_SHARED_LIBS=ON
 	cmake --build ada-build
-	sudo cmake --install ada-build
+	cmake --install ada-build
 	rm -rf ada.tgz ada-3.2.7 ada-build
 	# Install Linux-specific packages
 	brew install --quiet libseccomp


### PR DESCRIPTION
Figure out why CI job succeeded on bugfix branch: https://github.com/etwoo/youtube-unthrottle/actions/runs/16952144653

... but then failed on main: https://github.com/etwoo/youtube-unthrottle/actions/runs/16952252675

Maybe cache pollution? https://github.com/etwoo/youtube-unthrottle/actions/caches